### PR TITLE
fix(adapter): fixed settings i18nOverrides type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatfile/react",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "React Flatfile Adapter",
   "main": "dist/index.js",
   "scripts": {

--- a/src/interfaces/settings.ts
+++ b/src/interfaces/settings.ts
@@ -65,9 +65,9 @@ export interface ISettings {
   i18nOverrides?:
     | IDictionary<IDictionary<string>>
     | IDictionary<{
-        otherLocales: string[];
-        setLanguage: string | undefined;
-        overrides: IDictionary<string>;
+        otherLocales?: string[];
+        setLanguage?: string;
+        overrides: IDictionary<string | IDictionary<string>>;
       }>;
 
   /**


### PR DESCRIPTION
- [x] `setLanguage` and `otherLocales` should be optional
- [x] `overrides` has to be `IDictionary<string | IDictionary<string>>` (example below)

![image](https://user-images.githubusercontent.com/25963776/106066257-23793500-60c2-11eb-9fae-c49fa9022d71.png)
