### PR TITLE
feat(adapter): close importer when onData resolved without a message

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatfile/react",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "React Flatfile Adapter",
   "main": "dist/index.js",
   "scripts": {

--- a/src/components/FlatFileButton.tsx
+++ b/src/components/FlatFileButton.tsx
@@ -98,7 +98,9 @@ const FlatfileButton: FC<FlatfileButtonProps> = ({
     importer?.displayLoader();
     onData?.(results).then(
       (optionalMessage?: string | void) =>
-        importer?.displaySuccess(optionalMessage || undefined),
+        optionalMessage
+          ? importer?.displaySuccess(optionalMessage)
+          : importer?.close(),
       (error: Error | string) =>
         importer
           ?.requestCorrectionsFromUser(

--- a/src/components/FlatFileButton.tsx
+++ b/src/components/FlatFileButton.tsx
@@ -24,7 +24,7 @@ export type FlatfileButtonProps = React.DetailedHTMLProps<
   onBeforeFetch?: (req: IBeforeFetchRequest) => IBeforeFetchResponse;
   onInteractionEvent?: (req: IInteractionEvent) => void;
   onCancel?: () => void;
-  onData?: (results: FlatfileResults) => Promise<string | void>;
+  onData?: (results: FlatfileResults) => Promise<string | void | null>;
   onRecordChange?: (
     data: ScalarDictionaryWithCustom,
     index: number
@@ -97,9 +97,9 @@ const FlatfileButton: FC<FlatfileButtonProps> = ({
   const dataHandler = (results: FlatfileResults) => {
     importer?.displayLoader();
     onData?.(results).then(
-      (optionalMessage?: string | void) =>
-        optionalMessage
-          ? importer?.displaySuccess(optionalMessage)
+      (optionalMessage) =>
+        optionalMessage !== null
+          ? importer?.displaySuccess(optionalMessage || undefined)
           : importer?.close(),
       (error: Error | string) =>
         importer


### PR DESCRIPTION
- [x] If `onData` is resolved with `null`, it will close the importer instead of displaying a default message ("Success!")