### PR TITLE
feat(adapter): added preload option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatfile/react",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "React Flatfile Adapter",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Added `preload` (`true` by default) option to the config. By setting `preload={false}` none of the importers will be created on load, but instead will be created on the first click.

Recommended to use when creating multiple `FlatfileButton` elements.

> **NOTE**: `render` method will have first parameter (`importer`) equals `undefined` if `preload = false` until it's loaded