### PR TITLE
feat: update adapter for latest base adapter, and fix exports, cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+### 0.4.0
+
+> NOTE: If you need to access things like FlatfileResults, or other interfaces, they are available desctructured at the root level of `@flatfile/react` (or `@flatfile/adapter` if they are not re-exported here).
+
+- Removed all deep-import usages from `@flatfile/adapter` within this package.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1342,9 +1342,9 @@
       "dev": true
     },
     "@flatfile/adapter": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/@flatfile/adapter/-/adapter-2.6.4.tgz",
-      "integrity": "sha512-MGBVFzWLZNDr7M9+NQ57qtRI8wu4/48rvV6vbEzbpsuKSm9F3Ov6/KDjWDVtWeZ8cNiBByTv6jQxFAioH55FSA==",
+      "version": "2.8.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@flatfile/adapter/-/adapter-2.8.0-beta.1.tgz",
+      "integrity": "sha512-LGvR2DLU66jB83q1aN+90iBhs8Aw5+EXynSMVSZu9Vl8OFxJZ10K3wkt6w5ijbn9uS+HDr8kosh95B6JCVLGMw==",
       "requires": {
         "csstype": "^3.0.6",
         "element-class": "^0.2.2",
@@ -1361,9 +1361,9 @@
       },
       "dependencies": {
         "csstype": {
-          "version": "3.0.7",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.7.tgz",
-          "integrity": "sha512-KxnUB0ZMlnUWCsx2Z8MUsr6qV6ja1w9ArPErJaJaF8a5SOWoHLIszeCTKGRGRgtLgYrs1E8CHkNSP1VZTTPc9g=="
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
+          "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
         },
         "eventemitter3": {
           "version": "4.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatfile/react",
-  "version": "0.4.0",
+  "version": "0.4.0-beta.0",
   "description": "React Flatfile Adapter",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatfile/react",
-  "version": "0.3.5",
+  "version": "0.4.0",
   "description": "React Flatfile Adapter",
   "main": "dist/index.js",
   "scripts": {
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/FlatFilers/react-adapter#readme",
   "dependencies": {
-    "@flatfile/adapter": "^2.6.4"
+    "@flatfile/adapter": "^2.8.0-beta.1"
   },
   "devDependencies": {
     "@babel/core": "^7.11.1",

--- a/src/components/FlatFileButton.tsx
+++ b/src/components/FlatFileButton.tsx
@@ -1,17 +1,18 @@
-import FlatfileImporter, { FieldHookCallback } from '@flatfile/adapter';
-import {
+import FlatfileImporter, {
+  CustomerObject,
+  FieldHookCallback,
+  FlatfileResults,
   IBeforeFetchRequest,
   IBeforeFetchResponse,
-} from '@flatfile/adapter/build/main/obj.before-fetch';
-import CustomerObject from '@flatfile/adapter/build/main/obj.customer';
-import { IInteractionEvent } from '@flatfile/adapter/build/main/obj.interaction-event';
-import LoadOptionsObject from '@flatfile/adapter/build/main/obj.load-options';
-import { ISettings } from '@flatfile/adapter/build/main/obj.settings';
-import { IDataHookResponse } from '@flatfile/adapter/build/main/obj.validation-response';
-import FlatfileResults from '@flatfile/adapter/build/main/results';
+  IDataHookResponse,
+  IDictionary,
+  IInteractionEvent,
+  ISettings,
+  LoadOptionsObject,
+} from '@flatfile/adapter';
 import React, { FC, useCallback, useEffect, useRef, useState } from 'react';
 
-import { IDictionary, ScalarDictionaryWithCustom } from '../interfaces/general';
+import { ScalarDictionaryWithCustom } from '../interfaces/general';
 
 export type FlatfileButtonProps = React.DetailedHTMLProps<
   React.ButtonHTMLAttributes<HTMLButtonElement>,

--- a/src/dev.index.tsx
+++ b/src/dev.index.tsx
@@ -9,7 +9,10 @@ const config: FlatfileSettings = {
     { label: 'Email', key: 'email' },
   ],
 };
-const license = 'aa921983-4db2-4da1-a580-fbca0b1c75b2';
+/**
+ * @NOTE Apply your license key here
+ */
+const license = 'YOUR_LICENSE_KEY_HERE';
 const customer = { userId: '12345' };
 
 const data = [

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,21 @@
-import FlatfileImporter from '@flatfile/adapter';
-import { ISettings as FlatfileSettings } from '@flatfile/adapter/build/main/obj.settings';
-import FlatfileResults from '@flatfile/adapter/build/main/results';
+import FlatfileImporter, {
+  CustomerObject as FlatfileCustomer,
+  FieldHookCallback,
+  FlatfileResults,
+  IDataHookResponse,
+} from '@flatfile/adapter';
+import { ISettings as FlatfileSettings } from '@flatfile/adapter';
 
 import FlatfileButton from './components/FlatFileButton';
 
-export { FlatfileButton, FlatfileImporter, FlatfileResults, FlatfileSettings };
+export * from './interfaces/general';
+
+export {
+  FlatfileButton,
+  FlatfileCustomer,
+  FlatfileImporter,
+  FlatfileResults,
+  FieldHookCallback,
+  IDataHookResponse,
+  FlatfileSettings,
+};

--- a/src/interfaces/general.ts
+++ b/src/interfaces/general.ts
@@ -1,13 +1,6 @@
-export type ScalarDictionary = IDictionary<Nullable<IPrimitive>>;
-
-export interface IDictionary<V = string> {
-  [key: string]: V;
-}
+import { IPrimitive, Nullable, ScalarDictionary } from '@flatfile/adapter';
 
 export type ScalarDictionaryWithCustom = {
   $custom?: ScalarDictionary;
   [key: string]: Nullable<IPrimitive> | ScalarDictionary;
 };
-
-export type IPrimitive = string | number | boolean;
-export type Nullable<T> = T | undefined | null;


### PR DESCRIPTION
- Update to use the latest base adapter
- Fix exports & re-export important base adapter interfaces (for client use)
- Remove redundant interfaces and utilize base adapter ones

✅ Tested and works just as it did previously

![image](https://user-images.githubusercontent.com/2574412/115401339-48a8ab80-a1b8-11eb-9eb9-78fa4d56d21f.png)
