### PR TITLE
fix(sdk): React to re-init the importer;

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@flatfile/react",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@flatfile/react",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "MIT",
       "dependencies": {
         "@flatfile/sdk": "^1.0.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatfile/react",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "React Flatfile Adapter",
   "main": "dist/index.js",
   "scripts": {

--- a/src/components/FlatFileButton.tsx
+++ b/src/components/FlatFileButton.tsx
@@ -10,7 +10,7 @@ export type FlatfileButtonProps = {
   onClose?: () => void;
   onComplete?: (p: IEvents['complete']) => void;
   onError?: (e: Error) => void;
-  render?: (launch: () => void) => React.ReactElement;
+  render?: (payload: { launch: () => void }) => React.ReactElement;
   buttonProps?: React.DetailedHTMLProps<
     React.ButtonHTMLAttributes<HTMLButtonElement>,
     HTMLButtonElement
@@ -53,7 +53,7 @@ const FlatfileButton: FC<FlatfileButtonProps> = ({
   }, [token]);
 
   return render ? (
-    render(handleLaunch)
+    render({ launch: handleLaunch })
   ) : (
     <button {...buttonProps} onClick={() => handleLaunch()}>
       {children}

--- a/src/components/FlatFileButton.tsx
+++ b/src/components/FlatFileButton.tsx
@@ -1,5 +1,5 @@
-import { flatfileImporter, IEvents, IFlatfileImporter } from '@flatfile/sdk';
-import React, { FC, useMemo } from 'react';
+import { flatfileImporter, IEvents } from '@flatfile/sdk';
+import React, { FC, useCallback } from 'react';
 
 export type FlatfileButtonProps = {
   token: string;
@@ -10,7 +10,7 @@ export type FlatfileButtonProps = {
   onClose?: () => void;
   onComplete?: (p: IEvents['complete']) => void;
   onError?: (e: Error) => void;
-  render?: (importer: IFlatfileImporter) => React.ReactElement;
+  render?: (launch: () => void) => React.ReactElement;
   buttonProps?: React.DetailedHTMLProps<
     React.ButtonHTMLAttributes<HTMLButtonElement>,
     HTMLButtonElement
@@ -30,35 +30,32 @@ const FlatfileButton: FC<FlatfileButtonProps> = ({
   render,
   children,
 }) => {
-  const importer = useMemo(() => {
-    const _importer = flatfileImporter(token, {
+  const handleLaunch = useCallback(() => {
+    const importer = flatfileImporter(token, {
       ...(mountUrl ? { mountUrl } : {}),
       ...(apiUrl ? { apiUrl } : {}),
     });
 
     if (typeof onInit === 'function') {
-      _importer.on('init', onInit);
+      importer.on('init', onInit);
     }
     if (typeof onLaunch === 'function') {
-      _importer.on('launch', onLaunch);
+      importer.on('launch', onLaunch);
     }
     if (typeof onClose === 'function') {
-      _importer.on('close', onClose);
+      importer.on('close', onClose);
     }
     if (typeof onComplete === 'function') {
-      _importer.on('complete', onComplete);
+      importer.on('complete', onComplete);
     }
 
-    return _importer;
+    importer.launch().catch((e: Error) => onError?.(e));
   }, [token]);
 
   return render ? (
-    render(importer)
+    render(handleLaunch)
   ) : (
-    <button
-      {...buttonProps}
-      onClick={() => importer.launch().catch((e: Error) => onError?.(e))}
-    >
+    <button {...buttonProps} onClick={() => handleLaunch()}>
       {children}
     </button>
   );


### PR DESCRIPTION
`flatfileImporter()` has to be re-initialized every time user clicks a button, because `.close()` on the importer would destroy all of the event listeners.