### PR TITLE
chore: bump version to onprem safe sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@flatfile/react",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@flatfile/react",
-      "version": "3.0.4",
+      "version": "3.0.5",
       "license": "MIT",
       "dependencies": {
-        "@flatfile/sdk": "^1.0.5"
+        "@flatfile/sdk": "2.0.0-rc10"
       },
       "devDependencies": {
         "@babel/core": "^7.11.1",
@@ -60,8 +60,8 @@
         "webpack-merge": "^5.1.1"
       },
       "peerDependencies": {
-        "react": "^16.13.1 || ^17.0.0",
-        "react-dom": "^16.13.1 || ^17.0.0"
+        "react": "^16.13.1 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1495,15 +1495,9 @@
       "dev": true
     },
     "node_modules/@flatfile/sdk": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@flatfile/sdk/-/sdk-1.0.5.tgz",
-      "integrity": "sha512-45CLV8PgP4PY8rQFumA93RB5tR5yqnVKPxslxEul1pnHuPEvngkMV8LwB5BlO57YK0kh1+A+3equY5jrXmxKkg==",
-      "dependencies": {
-        "eventemitter3": "^4.0.7",
-        "graphql": "^15.5.0",
-        "graphql-request": "^3.4.0",
-        "graphql-subscriptions-client": "^0.16.0"
-      }
+      "version": "2.0.0-rc10",
+      "resolved": "https://registry.npmjs.org/@flatfile/sdk/-/sdk-2.0.0-rc10.tgz",
+      "integrity": "sha512-kWwEKMTPI9ev7A+mjJt8nkVupfQ/o1gL86QCkwZ7TfqwDTPjMBPWgbZW9gMXIYqD6M4BYum90oS4UeqJmyIE3g=="
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -3936,7 +3930,8 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
     },
     "node_modules/atob": {
       "version": "2.1.2",
@@ -4170,11 +4165,6 @@
       "engines": {
         "node": ">= 10.14.2"
       }
-    },
-    "node_modules/backo2": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
-      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
     },
     "node_modules/balanced-match": {
       "version": "1.0.0",
@@ -5363,6 +5353,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -6097,14 +6088,6 @@
         "sha.js": "^2.4.8"
       }
     },
-    "node_modules/cross-fetch": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
-      "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
-      "dependencies": {
-        "node-fetch": "2.6.1"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -6673,6 +6656,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -7782,7 +7766,8 @@
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "dev": true
     },
     "node_modules/events": {
       "version": "3.2.0",
@@ -8267,17 +8252,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/extract-files": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-9.0.0.tgz",
-      "integrity": "sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ==",
-      "engines": {
-        "node": "^10.17.0 || ^12.0.0 || >= 13.7.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jaydenseric"
       }
     },
     "node_modules/extsprintf": {
@@ -9192,55 +9166,6 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
       "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
       "dev": true
-    },
-    "node_modules/graphql": {
-      "version": "15.6.1",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.6.1.tgz",
-      "integrity": "sha512-3i5lu0z6dRvJ48QP9kFxBkJ7h4Kso7PS8eahyTFz5Jm6CvQfLtNIE8LX9N6JLnXTuwR+sIYnXzaWp6anOg0QQw==",
-      "engines": {
-        "node": ">= 10.x"
-      }
-    },
-    "node_modules/graphql-request": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-3.6.0.tgz",
-      "integrity": "sha512-p5qIuD+gyjuOJ8z9sEcfcLVK7HUB+/88hf/xGEzX330U3L2OR1JtaupLPmd1D2V7YtqWiEnSA3tX9vqZ4eGMhA==",
-      "dependencies": {
-        "cross-fetch": "^3.0.6",
-        "extract-files": "^9.0.0",
-        "form-data": "^3.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "14.x || 15.x"
-      }
-    },
-    "node_modules/graphql-request/node_modules/form-data": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/graphql-subscriptions-client": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/graphql-subscriptions-client/-/graphql-subscriptions-client-0.16.2.tgz",
-      "integrity": "sha512-4ggDgdU/7GnfY5GSavPKYQeoU2OPtSRZZ9LS9DzYssWA5aisi88JGTmy2w7AR0helWZRbZSAEsHqOmpD23tJCg==",
-      "dependencies": {
-        "backo2": "^1.0.2",
-        "eventemitter3": "^3.1.2",
-        "symbol-observable": "^1.2.0"
-      }
-    },
-    "node_modules/graphql-subscriptions-client/node_modules/eventemitter3": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
     },
     "node_modules/growly": {
       "version": "1.3.0",
@@ -14981,6 +14906,7 @@
       "version": "1.44.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
       "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -14989,6 +14915,7 @@
       "version": "2.1.27",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
       "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "dev": true,
       "dependencies": {
         "mime-db": "1.44.0"
       },
@@ -15387,14 +15314,6 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
-    },
-    "node_modules/node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      }
     },
     "node_modules/node-forge": {
       "version": "0.9.0",
@@ -19399,14 +19318,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/symbol-tree": {
@@ -23729,15 +23640,9 @@
       "dev": true
     },
     "@flatfile/sdk": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@flatfile/sdk/-/sdk-1.0.5.tgz",
-      "integrity": "sha512-45CLV8PgP4PY8rQFumA93RB5tR5yqnVKPxslxEul1pnHuPEvngkMV8LwB5BlO57YK0kh1+A+3equY5jrXmxKkg==",
-      "requires": {
-        "eventemitter3": "^4.0.7",
-        "graphql": "^15.5.0",
-        "graphql-request": "^3.4.0",
-        "graphql-subscriptions-client": "^0.16.0"
-      }
+      "version": "2.0.0-rc10",
+      "resolved": "https://registry.npmjs.org/@flatfile/sdk/-/sdk-2.0.0-rc10.tgz",
+      "integrity": "sha512-kWwEKMTPI9ev7A+mjJt8nkVupfQ/o1gL86QCkwZ7TfqwDTPjMBPWgbZW9gMXIYqD6M4BYum90oS4UeqJmyIE3g=="
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -25791,7 +25696,8 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
     },
     "atob": {
       "version": "2.1.2",
@@ -25985,11 +25891,6 @@
         "babel-plugin-jest-hoist": "^26.2.0",
         "babel-preset-current-node-syntax": "^0.1.2"
       }
-    },
-    "backo2": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
-      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -27001,6 +26902,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -27620,14 +27522,6 @@
         "sha.js": "^2.4.8"
       }
     },
-    "cross-fetch": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
-      "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
-      "requires": {
-        "node-fetch": "2.6.1"
-      }
-    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -28092,7 +27986,8 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
     "delegates": {
       "version": "1.0.0",
@@ -29005,7 +28900,8 @@
     "eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "dev": true
     },
     "events": {
       "version": "3.2.0",
@@ -29408,11 +29304,6 @@
           }
         }
       }
-    },
-    "extract-files": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-9.0.0.tgz",
-      "integrity": "sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ=="
     },
     "extsprintf": {
       "version": "1.3.0",
@@ -30170,50 +30061,6 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
       "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
       "dev": true
-    },
-    "graphql": {
-      "version": "15.6.1",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.6.1.tgz",
-      "integrity": "sha512-3i5lu0z6dRvJ48QP9kFxBkJ7h4Kso7PS8eahyTFz5Jm6CvQfLtNIE8LX9N6JLnXTuwR+sIYnXzaWp6anOg0QQw=="
-    },
-    "graphql-request": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-3.6.0.tgz",
-      "integrity": "sha512-p5qIuD+gyjuOJ8z9sEcfcLVK7HUB+/88hf/xGEzX330U3L2OR1JtaupLPmd1D2V7YtqWiEnSA3tX9vqZ4eGMhA==",
-      "requires": {
-        "cross-fetch": "^3.0.6",
-        "extract-files": "^9.0.0",
-        "form-data": "^3.0.0"
-      },
-      "dependencies": {
-        "form-data": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
-          }
-        }
-      }
-    },
-    "graphql-subscriptions-client": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/graphql-subscriptions-client/-/graphql-subscriptions-client-0.16.2.tgz",
-      "integrity": "sha512-4ggDgdU/7GnfY5GSavPKYQeoU2OPtSRZZ9LS9DzYssWA5aisi88JGTmy2w7AR0helWZRbZSAEsHqOmpD23tJCg==",
-      "requires": {
-        "backo2": "^1.0.2",
-        "eventemitter3": "^3.1.2",
-        "symbol-observable": "^1.2.0"
-      },
-      "dependencies": {
-        "eventemitter3": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-          "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
-        }
-      }
     },
     "growly": {
       "version": "1.3.0",
@@ -34805,12 +34652,14 @@
     "mime-db": {
       "version": "1.44.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.27",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
       "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "dev": true,
       "requires": {
         "mime-db": "1.44.0"
       }
@@ -35143,11 +34992,6 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
-    },
-    "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-forge": {
       "version": "0.9.0",
@@ -38491,11 +38335,6 @@
           }
         }
       }
-    },
-    "symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "symbol-tree": {
       "version": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatfile/react",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "React Flatfile Adapter",
   "main": "dist/index.js",
   "scripts": {
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/FlatFilers/react-adapter#readme",
   "dependencies": {
-    "@flatfile/sdk": "^1.0.5"
+    "@flatfile/sdk": "2.0.0-rc10"
   },
   "devDependencies": {
     "@babel/core": "^7.11.1",


### PR DESCRIPTION
This bumps the SDK version to an rc relesae which provides a patch for a routing error that on-prem customers need